### PR TITLE
Fix error message starting Chrome

### DIFF
--- a/eel/browsers.py
+++ b/eel/browsers.py
@@ -9,9 +9,9 @@ def open(start_pages, options):
         if chrome_path != None:
             if options['mode'] == 'chrome-app':
                 for url in start_urls:
-                    sps.Popen([chrome_path, '--app=%s' % url])
+                    sps.Popen([chrome_path, '--disable-gpu', '--app=%s' % url])
             else:
-                sps.Popen([chrome_path, '--new-window'] + start_urls)
+                sps.Popen([chrome_path, '--disable-gpu', '--new-window'] + start_urls)
         else:
             print("Can't find Chrome or Chromium, try different mode such as 'default'")
     elif False:


### PR DESCRIPTION
On 10.11.6 with Google Chrome 63.0.3239.132 the following error message
is raising:
GVA info: Successfully connected to the Intel plugin, offline Gen9
/Library/Caches/com.apple.xbs/Sources/AppleGVA/AppleGVA-9.1.12/Sources/S
lices/Driver/AVD_loader.cpp: failed to get a service for display 6
[7397:43779:0108/222738.679836:ERROR:browser_gpu_channel_host_factory.cc
(107)] Failed to launch GPU process.