### PR TITLE
from __future__ import print_function

### DIFF
--- a/examples/02 - callbacks/callbacks.py
+++ b/examples/02 - callbacks/callbacks.py
@@ -1,4 +1,6 @@
-import eel, random
+from __future__ import print_function
+import eel
+import random
 
 eel.init('web')
 


### PR DESCRIPTION
Allows __print()__ to be called inside of a lambda in Python 2.

flake8 testing of https://github.com/ChrisKnott/Eel on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./eel/__init__.py:62:28: E999 SyntaxError: invalid syntax
def start(*start_urls, block=True, options={}, size=None, position=None, geometry={}):
                           ^
./examples/02 - callbacks/callbacks.py:16:31: E999 SyntaxError: invalid syntax
eel.js_random()(lambda n: print('Got this from Javascript:', n))
                              ^
2     E999 SyntaxError: invalid syntax
```