### PR TITLE
Use # noqa to supress flake8 messages for now

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -60,7 +60,7 @@ def init(path):
     for js_function in _js_functions:
         _mock_js_function(js_function)
 
-def start(*start_urls, block=True, options={}, size=None, position=None, geometry={}):
+def start(*start_urls, block=True, options={}, size=None, position=None, geometry={}):  # noqa: TODO: Python 2
     for k, v in _default_options.items():
         if k not in options:
             options[k] = v


### PR DESCRIPTION
You can reject this PR if you want as we already have Python 2 running in __allow_failures__ mode.

I just wanted to make sure that you knew of the existence of # __noqa__.