### PR TITLE
Support Python 2 using future

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -1,9 +1,12 @@
+from __future__ import print_function
+from builtins import range
+from io import open
 import json as jsn, bottle as btl, bottle.ext.websocket as wbs, gevent as gvt
 import re as rgx, os, subprocess as sps, eel.browsers as brw, random as rnd, sys
 import pkg_resources as pkg
 
 _eel_js_file = pkg.resource_filename('eel', 'eel.js')
-_eel_js = open(_eel_js_file, encoding='utf8').read()
+_eel_js = open(_eel_js_file, encoding='utf-8').read()
 _websockets = []
 _call_return_values = {}
 _call_return_callbacks = {}
@@ -17,7 +20,7 @@ _default_options = {
     'mode': 'chrome-app',
     'host': 'localhost',
     'port': 8000,
-    'chromeFlags': ""
+    'chromeFlags': []
 }
 
 # Public functions
@@ -45,7 +48,7 @@ def init(path):
     for root, _, files in os.walk(root_path):
         for name in files:
             try:
-                with open(os.path.join(root, name), encoding='utf8') as file:                
+                with open(os.path.join(root, name), encoding='utf-8') as file:
                     contents = file.read()
                     expose_calls = set()
                     for expose_call in rgx.findall(r'eel\.expose\((.*)\)', contents):
@@ -60,8 +63,14 @@ def init(path):
     for js_function in _js_functions:
         _mock_js_function(js_function)
 
-def start(*start_urls, block=True, options={}, size=None, position=None, geometry={}):  # noqa: TODO: Python 2
-    for k, v in _default_options.items():
+def start(*start_urls, **kwargs):
+    block = kwargs.pop('block', True)
+    options = kwargs.pop('options', {})
+    size = kwargs.pop('size', None)
+    position = kwargs.pop('position', None)
+    geometry = kwargs.pop('geometry', {})
+
+    for k, v in list(_default_options.items()):
         if k not in options:
             options[k] = v
             

--- a/eel/__main__.py
+++ b/eel/__main__.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys, pkg_resources as pkg, PyInstaller.__main__ as pyi, os
 
 args = sys.argv[1:]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from io import open
 from setuptools import setup
 
 setup(
@@ -9,7 +10,8 @@ setup(
     package_data={
         'eel': ['eel.js'],
     },
-    install_requires=['bottle', 'bottle-websocket'],
+    install_requires=['bottle', 'bottle-websocket', 'future'],
+    python_requires='>=2.6',
     description='For little HTML GUI applications, with easy Python/JS interop',
     long_description=open('README.md', encoding='utf-8').readlines()[1],
     keywords=['gui', 'html', 'javascript', 'electron'],


### PR DESCRIPTION
Changes to support both Python 2 and 3 suggested by `futurize` tool from
the http://python-future.org/ package.

* Use `kwargs` instead of named arguments with default values
* Import `print_function` from `__future__`
* Import backported `range` from `builtins` provided by `future`
* Wrap `_default_options.items()` in a `list`

The `encoding` keyword argument for `open` is only supported in Python
2.6 and 2.7 if imported from the `io` module.

Change the default value of `_call_return_callbacks['chromeFlags']` to
an empty `list` fixing an error attempting to concatenate a `str` to a
`list`.

State the minimum required Python version in `setup.py`.