### PR TITLE
Don't require double parens in javascript, return promises instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ In Javascript, the language doesn't allow to us block while we wait for a callba
 async function run() {
   // Inside a function marked 'async' we can use the 'await' keyword.
   
-  let n = await eel.py_random()();    // Must prefix call with 'await', otherwise it's the same syntax
+  let n = await eel.py_random();    // Must prefix call with 'await', otherwise it's the same syntax
   console.log('Got this from Python: ' + n);
 }
 

--- a/eel/eel.js
+++ b/eel/eel.js
@@ -23,7 +23,7 @@ eel = {
             eel[name] = function() {
                 let call_object = eel._call_object(name, arguments);
                 eel._mock_queue.push(call_object);
-                return eel._call_return(call_object);
+                return eel._call_return(call_object)();
             }
         }
     },
@@ -33,7 +33,7 @@ eel = {
         eel[name] = function() {
             let call_object = eel._call_object(func_name, arguments);
             eel._websocket.send(eel._toJSON(call_object));
-            return eel._call_return(call_object);
+            return eel._call_return(call_object)();
         }
     },
     

--- a/examples/02 - callbacks/web/callbacks.html
+++ b/examples/02 - callbacks/web/callbacks.html
@@ -16,10 +16,10 @@
         }
         
         // Call Python function, and pass explicit callback function
-        eel.py_random()(print_num);
+        eel.py_random().then(print_num);
         
         // Do the same with an inline callback
-        eel.py_random()(n => console.log('Got this from Python: ' + n));
+        eel.py_random().then(n => console.log('Got this from Python: ' + n));
         
         </script>
     </head>

--- a/examples/03 - sync_callbacks/web/sync_callbacks.html
+++ b/examples/03 - sync_callbacks/web/sync_callbacks.html
@@ -17,7 +17,7 @@
             // Get result returned synchronously by 
             //  using 'await' and passing nothing in second brackets
             //        v                   v
-            let n = await eel.py_random()();
+            let n = await eel.py_random();
             console.log('Got this from Python: ' + n);
         }
         

--- a/examples/04 - file_access/web/file_access.html
+++ b/examples/04 - file_access/web/file_access.html
@@ -10,7 +10,7 @@
             let file_div = document.getElementById('file-name');
             
             // Call into Python so we can access the file system
-            let random_filename = await eel.pick_file(folder)();
+            let random_filename = await eel.pick_file(folder);
             file_div.innerHTML = random_filename;
         }
         


### PR DESCRIPTION
In javascript, it's possible to always return a Promise, thus avoiding the need for calling the return value of the eel.exposed_python_function() call.