### PR TITLE
use whichcraft to replace shu.which

### DIFF
--- a/eel/browsers.py
+++ b/eel/browsers.py
@@ -1,4 +1,5 @@
 import webbrowser as wbr, sys, subprocess as sps, os
+from whichcraft import which
 
 def open(start_pages, options):
     base_url = 'http://%s:%d/' % (options['host'], options['port'])
@@ -47,7 +48,7 @@ def find_chrome_linux():
                     'google-chrome-stable']
 
     for name in chrome_names:
-        chrome = shu.which(name)
+        chrome = which(name)
         if chrome is not None:
             return chrome
     return None

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     package_data={
         'eel': ['eel.js'],
     },
-    install_requires=['bottle', 'bottle-websocket', 'future'],
+    install_requires=['bottle', 'bottle-websocket', 'future', 'whichcraft'],
     python_requires='>=2.6',
     description='For little HTML GUI applications, with easy Python/JS interop',
     long_description=open('README.md', encoding='utf-8').readlines()[1],


### PR DESCRIPTION
whichcraft is essentially a back-port of shu.which (see https://github.com/pydanny/whichcraft).  This enables use of Eel with Python 2.7.  I have not yet tested this with Python 3.

There is an alternative package that does the same things as whichcraft, but I can't seem to recall what it's called!