### PR TITLE
Added support for ephemeral ports

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -11,6 +11,7 @@ import eel.browsers as brw
 import random as rnd
 import sys
 import pkg_resources as pkg
+import socket
 
 _eel_js_file = pkg.resource_filename('eel', 'eel.js')
 _eel_js = open(_eel_js_file, encoding='utf-8').read()
@@ -96,6 +97,12 @@ def start(*start_urls, **kwargs):
 
     _start_geometry['default'] = {'size': size, 'position': position}
     _start_geometry['pages'] = geometry
+
+    if options['port'] == 0:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(('localhost', 0))
+        options['port'] = sock.getsockname()[1]
+        sock.close()
 
     brw.open(start_urls, options)
     


### PR DESCRIPTION
This is a fix for when port is set to 0; a dynamic port will now be selected. As talked about in issue #42 this seemed like a good fit and is a clean fix.

I have not made this default but if you want to, a simple change of 8000 to 0 on \_\_init\_\_.py:31 will fix this. Will need to update the readme if this is done (I think it's better if you word it if you decide to make it the default).