### PR TITLE
Changes keys prelation. Fix `UnboundLocalError` if both keys aren't found.

### DIFF
--- a/eel/chrome.py
+++ b/eel/chrome.py
@@ -54,12 +54,14 @@ def find_chrome_win():
     import winreg as reg
     reg_path = r'SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe'
 
-    for install_type in reg.HKEY_LOCAL_MACHINE, reg.HKEY_CURRENT_USER:
+    for install_type in reg.HKEY_CURRENT_USER, reg.HKEY_LOCAL_MACHINE:
         try:
             reg_key = reg.OpenKey(install_type, reg_path, 0, reg.KEY_READ)
             chrome_path = reg.QueryValue(reg_key, None)
             reg_key.Close()
         except WindowsError:
-            pass
+            chrome_path = None
+        else:
+            break
 
     return chrome_path


### PR DESCRIPTION
User settings should take precedence over global settings. In addition, if neither is present `chrome_path` will be referenced before assignment.