### PR TITLE
Support alternate Chrome.app locations on Mac

### DIFF
--- a/eel/chrome.py
+++ b/eel/chrome.py
@@ -37,7 +37,7 @@ def find_chrome_mac():
     name = 'Google Chrome.app'
     alternate_dirs = [x for x in sps.check_output(["mdfind", name]).decode().split('\n') if x.endswith(name)] 
     if len(alternate_dirs):
-        return alternate_dirs[0]
+        return alternate_dirs[0] + '/Contents/MacOS/Google Chrome'
     return None
 
 

--- a/eel/chrome.py
+++ b/eel/chrome.py
@@ -33,6 +33,11 @@ def find_chrome_mac():
     default_dir = r'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
     if os.path.exists(default_dir):
         return default_dir
+    # use mdfind ci to locate Chrome in alternate locations and return the first one
+    name = 'Google Chrome.app'
+    alternate_dirs = [x for x in sps.check_output(["mdfind", name]).decode().split('\n') if x.endswith(name)] 
+    if len(alternate_dirs):
+        return alternate_dirs[0]
     return None
 
 


### PR DESCRIPTION
Support alternate locations for Google Chrome.app on Mac

My installed version of Google Chrome sits in a subfolder of /Applications. This helps to find alternate locations.

Using the command:
`mdfind kMDItemContentType=\*.application-bundle | grep "Google Chrome.app"`
returns much faster but I could not get it to work reliably/properly with the subprocess module.