### PR TITLE
Make eel docs easier to find from PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,5 @@ setup(
     description='For little HTML GUI applications, with easy Python/JS interop',
     long_description=open('README.md', encoding='utf-8').readlines()[1],
     keywords=['gui', 'html', 'javascript', 'electron'],
+    homepage='https://github.com/ChrisKnott/Eel',
 )


### PR DESCRIPTION
When I hear about new packages I want to try I typically go to PyPI first and look for documentation and GitHub links from there.

This will add a link to GitHub on eel's PyPI page