### PR TITLE
Fix jinja example; add changelog and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change log
+
+## v0.10.0
+* Corrective version bump after new feature included in 0.9.13
+* Fix a bug with example 06 for Jinja templating; the `templates` kwarg to `eel.start` takes a filepath, not a bool.
+
+## v0.9.13
+* Add support for Jinja templating.
+
+## Earlier
+* No changelog notes for earlier versions.

--- a/examples/06 - jinja_templates/hello.py
+++ b/examples/06 - jinja_templates/hello.py
@@ -9,4 +9,4 @@ def say_hello_py(x):
 say_hello_py('Python World!')
 eel.say_hello_js('Python World!')   # Call a Javascript function
 
-eel.start('templates/hello.html', size=(300, 200), templates=True)    # Start
+eel.start('templates/hello.html', size=(300, 200), templates='templates')    # Start

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='Eel',
-    version='0.9.13',
+    version='0.10.0',
     author='Chris Knott',
     author_email='chrisknott@hotmail.co.uk',
     packages=['eel'],


### PR DESCRIPTION
The `templates` kwarg to `eel.start` takes a string rather than a
boolean now, where the string is a filepath relative to eel's root
directory.

Add a changelog to the project in order to track significant/relevant
changes made to the codebase and ease the process for developers
updating versions.

Also bumps the version to 0.10.0 to account for the new feature added in
0.9.13. This keeps us roughly in line with [semantic
versioning](https://semver.org/).