### PR TITLE
Only render jinja templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## v0.10.2
+* Only render templates from within the declared jinja template directory.
+
 ## v0.10.0
 * Corrective version bump after new feature included in 0.9.13
 * Fix a bug with example 06 for Jinja templating; the `templates` kwarg to `eel.start` takes a filepath, not a bool.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,17 @@
 # Change log
 
-## v0.10.2
+### v0.10.2
 * Only render templates from within the declared jinja template directory.
 
-## v0.10.1
+### v0.10.1
 * Avoid name collisions when using Electron, so jQuery etc work normally
 
 ## v0.10.0
 * Corrective version bump after new feature included in 0.9.13
 * Fix a bug with example 06 for Jinja templating; the `templates` kwarg to `eel.start` takes a filepath, not a bool.
 
-## v0.9.13
+### v0.9.13
 * Add support for Jinja templating.
 
-## Earlier
+### Earlier
 * No changelog notes for earlier versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## v0.10.2
 * Only render templates from within the declared jinja template directory.
 
+## v0.10.1
+* Avoid name collisions when using Electron, so jQuery etc work normally
+
 ## v0.10.0
 * Corrective version bump after new feature included in 0.9.13
 * Fix a bug with example 06 for Jinja templating; the `templates` kwarg to `eel.start` takes a filepath, not a bool.

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -153,12 +153,14 @@ def _eel():
 
 @btl.route('/<path:path>')
 def _static(path):
-    if _jinja_env != None:
-        n = len(_jinja_templates + '/')
+    template_prefix = _jinja_templates + '/'
+
+    if _jinja_env != None and path.startswith(template_prefix):
+        n = len(template_prefix)
         template = _jinja_env.get_template(path[n:])
         return template.render()
-    else:
-        return btl.static_file(path, root=root_path)
+
+    return btl.static_file(path, root=root_path)
     
 
 @btl.get('/eel', apply=[wbs.websocket])

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='Eel',
-    version='0.10.1',
+    version='0.10.2',
     author='Chris Knott',
     author_email='chrisknott@hotmail.co.uk',
     packages=['eel'],


### PR DESCRIPTION
We should only try to render templates from the declared jinja template
directory. For all other files, we simply want to serve them as static
files directly (for example, `favicon.ico`)

Update the changelog with details for 0.10.1 and 0.10.2 (this) patches.

Fix #120 