### PR TITLE
 Check if using templating before concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### v0.10.3
+* Fix a bug that prevented using Eel without Jinja templating. 
+
 ### v0.10.2
 * Only render templates from within the declared jinja template directory.
 

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -153,12 +153,13 @@ def _eel():
 
 @btl.route('/<path:path>')
 def _static(path):
-    template_prefix = _jinja_templates + '/'
+    if _jinja_templates is not None:
+        template_prefix = _jinja_templates + '/'
 
-    if _jinja_env != None and path.startswith(template_prefix):
-        n = len(template_prefix)
-        template = _jinja_env.get_template(path[n:])
-        return template.render()
+        if _jinja_env is not None and path.startswith(template_prefix):
+            n = len(template_prefix)
+            template = _jinja_env.get_template(path[n:])
+            return template.render()
 
     return btl.static_file(path, root=root_path)
     

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     install_requires=['bottle', 'bottle-websocket', 'future', 'whichcraft'],
     python_requires='>=2.6',
     description='For little HTML GUI applications, with easy Python/JS interop',
-    long_description=open('README.md', encoding='utf-8').readlines()[1],
+    long_description=open('README.md', encoding='utf-8').read(),
     keywords=['gui', 'html', 'javascript', 'electron'],
     homepage='https://github.com/ChrisKnott/Eel',
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='Eel',
-    version='0.10.2',
+    version='0.10.3',
     author='Chris Knott',
     author_email='chrisknott@hotmail.co.uk',
     packages=['eel'],


### PR DESCRIPTION
We should only check the path against the jinja templating directory if
`_jinja_templates` is configured, i.e. not None.

Use full readme for project description.

Bump to v0.10.3