### PR TITLE
Add option to let Bottle listen on all interfaces

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -29,6 +29,7 @@ _on_close_callback = None
 _default_options = {
     'mode': 'chrome-app',
     'host': 'localhost',
+    'all-interfaces': False,
     'port': 8000,
     'chromeFlags': []
 }
@@ -120,8 +121,12 @@ def start(*start_urls, **kwargs):
     brw.open(start_urls, options)
     
     def run_lambda():
+        if options['all-interfaces'] == True:
+            HOST = '0.0.0.0'
+        else:
+            HOST = options['host']
         return btl.run(
-            host=options['host'],
+            host=HOST,
             port=options['port'],
             server=wbs.GeventWebSocketServer,
             quiet=True)


### PR DESCRIPTION
Added option to allow bottle server to listen on all interfaces.  Bottle allows listening on all interfaces when the host is set to '0.0.0.0' as per[ documentation](https://bottlepy.org/docs/dev/deployment.html)  

Without this change, setting the host to '0.0.0.0' via eel options fails because this is not a valid address for the web browser to navigate to in order to access the server.  The added option still allows a single IP address to be specified so that the browser that eel launches can access it, but passes '0.0.0.0' to the bottle server so that the GUI can be accessed on all IP addresses via browsers on the LAN.  The default value is set so that behavior does not change unless this new options is specifically added and set to True.