### PR TITLE
Add keyword arg to let Bottle listen on all interfaces

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -38,6 +38,7 @@ _start_args = {
     'geometry':         {},                         # Dictionary of size/position for all windows
     'close_callback':   None,                       # Callback for when all windows have closed
     'app_mode':  True,                              # (Chrome specific option)
+    'all_interfaces': False,                        # Allow bottle server to listen for connections on all interfaces
 }
 
 # == Temporary (suppressable) error message to inform users of breaking API change for v1.0.0 ===
@@ -130,8 +131,12 @@ def start(*start_urls, **kwargs):
     show(*start_urls)
     
     def run_lambda():
+        if _start_args['all_interfaces'] == True:
+            HOST = '0.0.0.0'
+        else:
+            HOST = _start_args['host']
         return btl.run(
-            host=_start_args['host'],
+            host=HOST,
             port=_start_args['port'],
             server=wbs.GeventWebSocketServer,
             quiet=True)


### PR DESCRIPTION
Replacement for #139  

Added option to allow bottle server to listen on all interfaces.  Bottle allows listening on all interfaces when the host is set to '0.0.0.0' as per documentation:  https://bottlepy.org/docs/dev/deployment.html

Without this change setting the host to '0.0.0.0' via eel options fails because this is not a valid address for the web browser to navigate to in order to access the server.  The added keyword arg still allows a single IP address to be specified for the browser that eel launches to use, but passes '0.0.0.0' to the bottle server so that the GUI can be accessed on all IP addresses.  For example, both 'localhost' and one or more LAN IPs.  Default is set so that behavior does not change unless this new keyword arg is specifically added and set to True.