### PR TITLE
Add time_shutdown on the start () function parameter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ As of Eel v0.12.0, the following options are available to `start()`:
  - **close_callback**, a lambda or function that is called when a websocket to a window closes (i.e. when the user closes the window). It should take two arguments; a string which is the relative path of the page that just closed, and a list of other websockets that are still open. *Default: `None`*
  - **app**, an instance of Bottle which will be used rather than creating a fresh one. This can be used to install middleware on the
  instance before starting eel, e.g. for session management, authentication, etc.
+ - **time_shutdown**, timer configurable for Eel's shutdown detection mechanism, whereby when any websocket closes, it waits time_shutdown seconds (default 1 second), and then checks if there are now any websocket connections. If not, then Eel closes. In case the user has closed the browser and wants to exit the program.
 
 
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ As of Eel v0.12.0, the following options are available to `start()`:
  - **close_callback**, a lambda or function that is called when a websocket to a window closes (i.e. when the user closes the window). It should take two arguments; a string which is the relative path of the page that just closed, and a list of other websockets that are still open. *Default: `None`*
  - **app**, an instance of Bottle which will be used rather than creating a fresh one. This can be used to install middleware on the
  instance before starting eel, e.g. for session management, authentication, etc.
- - **time_shutdown**, timer configurable for Eel's shutdown detection mechanism, whereby when any websocket closes, it waits time_shutdown seconds (default 1 second), and then checks if there are now any websocket connections. If not, then Eel closes. In case the user has closed the browser and wants to exit the program.
+ - **time_shutdown**, timer configurable for Eel's shutdown detection mechanism, whereby when any websocket closes, it waits  `time_shutdown  seconds`, and then checks if there are now any websocket connections. If not, then Eel closes. In case the user has closed the browser and wants to exit the program. Default: `1.0`
 
 
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ As of Eel v0.12.0, the following options are available to `start()`:
  - **close_callback**, a lambda or function that is called when a websocket to a window closes (i.e. when the user closes the window). It should take two arguments; a string which is the relative path of the page that just closed, and a list of other websockets that are still open. *Default: `None`*
  - **app**, an instance of Bottle which will be used rather than creating a fresh one. This can be used to install middleware on the
  instance before starting eel, e.g. for session management, authentication, etc.
- - **time_shutdown**, timer configurable for Eel's shutdown detection mechanism, whereby when any websocket closes, it waits  `time_shutdown  seconds`, and then checks if there are now any websocket connections. If not, then Eel closes. In case the user has closed the browser and wants to exit the program. Default: `1.0`
+ - **shutdown_delay**, timer configurable for Eel's shutdown detection mechanism, whereby when any websocket closes, it waits `shutdown_delay` seconds, and then checks if there are now any websocket connections. If not, then Eel closes. In case the user has closed the browser and wants to exit the program. Default: `1.0`
 
 
 

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -54,14 +54,6 @@ _start_args = {
     'time_shutdown' : 1.0                           # timer verification if browser closed  
 }
 
-# verify time_shutdown is correct value 
-try:
-    _start_args['time_shutdown'] = float(_start_args['time_shutdown'])
-except:
-    print(_start_args['time_shutdown'], 'is not a correct number, value is changed 1.0')
-    _start_args['time_shutdown'] = 1.0
-        
-       
 # == Temporary (suppressable) error message to inform users of breaking API change for v1.0.0 ===
 _start_args['suppress_error'] = False
 api_error_message = '''
@@ -162,6 +154,13 @@ def start(*start_urls, **kwargs):
         _start_args['jinja_env'] = Environment(loader=FileSystemLoader(templates_path),
                                  autoescape=select_autoescape(['html', 'xml']))
 
+    # verify time_shutdown is correct value 
+    try:
+        _start_args['time_shutdown'] = float(_start_args['time_shutdown'])
+    except:
+        print(_start_args['time_shutdown'], \
+            'is not a correct number for time_shutdown \nValue is changed by default 1.0')
+        _start_args['time_shutdown'] = 1.0
 
     # Launch the browser to the starting URLs
     show(*start_urls)

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -51,8 +51,17 @@ _start_args = {
     'disable_cache': True,                          # Sets the no-store response header when serving assets
     'default_path': 'index.html',                   # The default file to retrieve for the root URL
     'app': btl.default_app(),                       # Allows passing in a custom Bottle instance, e.g. with middleware
+    'time_shutdown' : 1.0                           # timer verification if browser closed  
 }
 
+# verify time_shutdown is correct value 
+try:
+    _start_args['time_shutdown'] = float(_start_args['time_shutdown'])
+except:
+    print(_start_args['time_shutdown'], 'is not a correct number, value is changed 1.0')
+    _start_args['time_shutdown'] = 1.0
+        
+       
 # == Temporary (suppressable) error message to inform users of breaking API change for v1.0.0 ===
 _start_args['suppress_error'] = False
 api_error_message = '''
@@ -379,8 +388,8 @@ def _websocket_close(page):
     else:
         if _shutdown:
             _shutdown.kill()
-
-        _shutdown = gvt.spawn_later(1.0, _detect_shutdown)
+        
+        _shutdown = gvt.spawn_later(_start_args['time_shutdown'], _detect_shutdown)
 
 
 def _set_response_headers(response):


### PR DESCRIPTION
 timer configurable for Eel's shutdown detection mechanism, whereby when any websocket closes, it waits time_shutdown seconds (default 1 second), and then checks if there are now any websocket connections. If not, then Eel closes. In case the user has closed the browser and wants to exit the program. 


Try to fix #355 issues: Increase  the value __time_shutdown__ higher to avoid stopping Eel.