### PR TITLE
Ignoring files prefix and use only files implemented

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -101,15 +101,27 @@ EXPOSED_JS_FUNCTIONS = pp.ZeroOrMore(
 )
 
 
-def init(path, allowed_extensions=['.js', '.html', '.txt', '.htm',
-                                   '.xhtml', '.vue'], js_result_timeout=10000):
+def init(
+    path,
+    allowed_extensions=[".js", ".html", ".txt", ".htm", ".xhtml", ".vue"],
+    exclude_prefix=[],
+    js_result_timeout=10000,
+    use_only_files=None,
+):
     global root_path, _js_functions, _js_result_timeout
     root_path = _get_real_path(path)
 
     js_functions = set()
     for root, _, files in os.walk(root_path):
         for name in files:
+
+            if use_only_files and name not in use_only_files:
+                continue
+
             if not any(name.endswith(ext) for ext in allowed_extensions):
+                continue
+
+            if exclude_prefix and any(name.startswith(exc) for exc in exclude_prefix):
                 continue
 
             try:

--- a/tests/data/init_test/ignore_test.html
+++ b/tests/data/init_test/ignore_test.html
@@ -1,0 +1,22 @@
+<!-- Below is from: https://github.com/samuelhwilliams/Eel/blob/master/examples/05%20-%20input/web/main.html  -->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script type="text/javascript" src="/eel.js"></script>
+    <script type="text/javascript">
+        $(function () {
+            eel.expose(ignore_test);               // Expose this function to Python
+            function ignore_test(x) {
+                console.log("Ignore test.");
+            }
+        });
+    </script>
+</head>
+
+<body>
+    <h1>Testing if some js file can be ignored from parsing.</h1>
+</body>
+
+</html>

--- a/tests/unit/test_eel.py
+++ b/tests/unit/test_eel.py
@@ -24,6 +24,16 @@ def test_exposed_js_functions(js_code, expected_matches):
 def test_init():
     """Test eel.init() against a test directory and ensure that all JS functions are in the global _js_functions."""
     eel.init(path=INIT_DIR)
-    result = eel._js_functions.sort()
-    functions = ['show_log', 'js_random', 'show_log_alt', 'say_hello_js'].sort()
-    assert result == functions, f'Expected {functions} (found: {result}) in {INIT_DIR}'
+    result = eel._js_functions
+    functions = ["show_log", "js_random", "ignore_test", "show_log_alt", "say_hello_js"]
+    assert set(result) == set(functions), f"Expected {functions} (found: {result}) in {INIT_DIR}"
+
+    eel.init(path=INIT_DIR, exclude_prefix="ignore")
+    result = eel._js_functions
+    functions = ["show_log", "js_random", "show_log_alt", "say_hello_js"]
+    assert set(result) == set(functions), f"Expected {functions} (found: {result}) in {INIT_DIR}"
+
+    eel.init(path=INIT_DIR, use_only_files=["hello.html"])
+    result = eel._js_functions
+    functions = ["js_random", "say_hello_js"]
+    assert set(result) == set(functions), f"Expected {functions} (found: {result}) in {INIT_DIR}"


### PR DESCRIPTION
Proposed solution for [issue 393 - Init kakes 20 seconds](https://github.com/ChrisKnott/Eel/issues/393)

Both proposed ways implemented. Its possible to define prefix that will be always ignored (possible to setup for npm modules). Also it's possible to define what particular files will be parsed.

New params in inits are called `exclude_prefix` and `use_only_files` feel free to change names as you wish.

__init__.py  in tests added so the tests can run in local IDE and imports works from root.

In added tests, also original tests changed a bit as sort() function returns none and comparison would fail even if not all functions would be parsed.