### PR TITLE
Clarify current maintenance status in readme before project archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Eel
 
+> [!IMPORTANT]
+> This project is effectively unmaintained. It has not received regular update in a number of years, and there are no plans by active maintainers for this to change. Please treat this project in that light and use it with careful consideration towards how you will secure and maintain anything you build using it.
+
 [![PyPI version](https://img.shields.io/pypi/v/Eel?style=for-the-badge)](https://pypi.org/project/Eel/)
 [![PyPi Downloads](https://img.shields.io/pypi/dm/Eel?style=for-the-badge)](https://pypistats.org/packages/eel)
 ![Python](https://img.shields.io/pypi/pyversions/Eel?style=for-the-badge)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eel
 
-> [!IMPORTANT]
+> [!CAUTION]
 > This project is effectively unmaintained. It has not received regular update in a number of years, and there are no plans by active maintainers for this to change. Please treat this project in that light and use it with careful consideration towards how you will secure and maintain anything you build using it.
 
 [![PyPI version](https://img.shields.io/pypi/v/Eel?style=for-the-badge)](https://pypi.org/project/Eel/)


### PR DESCRIPTION
Eel has not received regular updates for a number of years. Given the significant passage of time, it feels appropriate and responsible to note this publicly.

This PR will be followed up by the archival of the repository to solidify that there are no currently plans or capacity to maintain it into the future.

I am not willing to handover the project to new maintainers at this time due to the verification requirements to ensure it lands in reasonable hands rather than becoming a source of exploit, so unfortunately the community may need to self-organise around a fork if there is separate appetite after the fact to take on security, maintenance and development of new features.

I'm aware this ma be unpopular but it seems more like an acknowledgement of the reality of the situation for Eel more than anything else.

I will not be taking down the pypi package, so Eel as it stands will continue to be available.